### PR TITLE
Formating + Use fixed versions in package.json

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -89,3 +89,21 @@ jobs:
       run: dotnet pack --configuration Release -o ${{ env.NUGET_OUTPUT }} /p:PackageVersion=${{ needs.create-release.outputs.version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
     - name: Push NuGet packages
       run: dotnet nuget push --skip-duplicate '${{ env.NUGET_OUTPUT }}/*.nupkg' --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  js-cd:
+    name: JavaScript CD
+    runs-on: ubuntu-latest
+    needs: [context, create-release]
+    if: ${{ needs.context.outputs.should-publish == 'true'  }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Push npmjs packages
+      working-directory: ./Source/JavaScript
+      run: yarn publish --new-version ${{ needs.create-release.outputs.version }} --no-git-tag-version
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dolittle/protobuf.build",
-    "version": "2.0.2",
+    "version": "0.0.0",
     "description": "",
     "publishConfig": {
         "access": "public"

--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dolittle/protobuf.build",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "",
     "publishConfig": {
         "access": "public"

--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "@dolittle/protobuf.build",
-  "version": "2.0.1",
-  "description": "",
-  "publishConfig": {
-    "access": "public"
-  },
-  "bin": {
-    "dolittle_proto_build": "./build.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dolittle-tools/JavaScript.Protobuf.git"
-  },
-  "author": "",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/dolittle-tools/JavaScript.Protobuf/issues"
-  },
-  "homepage": "https://github.com/dolittle-tools/JavaScript.Protobuf#readme",
-  "dependencies": {
-    "@types/google-protobuf": "^3.7.4",
-    "@types/node": "^14.14.7",
-    "del-cli": "^3.0.1",
-    "glob": "^7.1.6",
-    "@grpc/grpc-js": "^1.2.0",
-    "grpc_tools_node_protoc_ts": "^5.0.1",
-    "grpc-tools": "^1.9.1",
-    "grpc-web": "^1.2.1",
-    "ts-protoc-gen": "^0.13.0",
-    "typescript": "^3.8.3"
-  },
-  "devDependencies": {}
+    "name": "@dolittle/protobuf.build",
+    "version": "2.0.1",
+    "description": "",
+    "publishConfig": {
+        "access": "public"
+    },
+    "bin": {
+        "dolittle_proto_build": "./build.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dolittle-tools/JavaScript.Protobuf.git"
+    },
+    "author": "",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/dolittle-tools/JavaScript.Protobuf/issues"
+    },
+    "homepage": "https://github.com/dolittle-tools/JavaScript.Protobuf#readme",
+    "dependencies": {
+        "@types/google-protobuf": "3.7.4",
+        "@types/node": "14.14.35",
+        "del-cli": "3.0.1",
+        "glob": "7.1.6",
+        "@grpc/grpc-js": "1.2.11",
+        "grpc_tools_node_protoc_ts": "5.1.3",
+        "grpc-tools": "1.11.0",
+        "grpc-web": "1.2.1",
+        "ts-protoc-gen": "0.14.0",
+        "typescript": "^3.8.3"
+    },
+    "devDependencies": {}
 }


### PR DESCRIPTION
Upgrade versions and use fixed versions for the javascript protobuf build tool

This repo is kinda in a limbo with how releases are done. The js package is on version 2.0.1 and dotnet package is on 1.something. Should we do monorepo releases?