### PR TITLE
Fix authentication for yarn publish

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -102,6 +102,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+        always-auth: true
     - name: Push npmjs packages
       working-directory: ./Source/JavaScript
       run: yarn publish --new-version ${{ needs.create-release.outputs.version }} --no-git-tag-version


### PR DESCRIPTION
## Summary

Adds `always-auth: true` to fix authentication for `yarn publish`.
