### PR TITLE
Set npm registry address to force use of NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-        always-auth: true
+        registry-url: 'https://registry.npmjs.org'
     - name: Update package version
       working-directory: ./Source/JavaScript
       run: npm version ${{ needs.create-release.outputs.version }}


### PR DESCRIPTION
## Summary

Set npm registry address to force use of NODE_AUTH_TOKEN
