### PR TITLE
Add support for specifying output directory for JS/TS generator

### DIFF
--- a/Source/JavaScript/GenerateOptions.ts
+++ b/Source/JavaScript/GenerateOptions.ts
@@ -5,6 +5,7 @@ import { GenerationTarget } from './GenerationTarget';
 
 export type GenerateOptions = {
     readonly target: GenerationTarget;
+    readonly output: string;
     readonly paths: readonly string[];
     readonly includes: readonly string[];
     readonly rewrites: readonly {readonly from: string, readonly to: string, readonly package: boolean}[];

--- a/Source/JavaScript/generateAction.ts
+++ b/Source/JavaScript/generateAction.ts
@@ -7,6 +7,7 @@ import { GenerationTarget } from './GenerationTarget';
 type GenerateActionCallback = (options: GenerateOptions) => Promise<void> | void;
 
 type Options = {
+    O: string,
     I: string[],
     R: string[],
     skipEmptyFiles?: boolean,
@@ -16,6 +17,7 @@ export const generateAction = (target: GenerationTarget, action: GenerateActionC
     return (paths: string[], options: Options) => {
         action({ 
             target,
+            output: options.O,
             paths,
             includes: options.I,
             rewrites: options.R.map(_ => {

--- a/Source/JavaScript/index.ts
+++ b/Source/JavaScript/index.ts
@@ -9,16 +9,18 @@ import { generateAction } from './generateAction';
 import { GenerationTarget } from './GenerationTarget';
 import { Generator } from './Generator';
 
-const generator = new Generator('./build');
+const generator = new Generator();
 
 const program = new Command('dolittle_proto_build');
 
+const output = new Option('-O <path>', 'Output path').default('./build');
 const includes = new Option('-I <path>', 'Include path (multiple allowed)');
 const rewrite = new Option('-R <rewrite>', 'Rewrite file paths (multiple allowed)');
 const skipEmptyFiles = new Option('--skip-empty-files', 'Remove files generated without any content');
 
 program
     .command('grpc-node <paths...>')
+    .addOption(output)
     .addOption(repeated(includes))
     .addOption(repeated(rewrite))
     .addOption(skipEmptyFiles)
@@ -27,6 +29,7 @@ program
 
 program
     .command('grpc-web <paths...>')
+    .addOption(output)
     .addOption(repeated(includes))
     .addOption(repeated(rewrite))
     .addOption(skipEmptyFiles)


### PR DESCRIPTION
## Summary

Added support for specifying output directory for JS/TS generator

### Added

- Support `-O <path>` option for the JS/TS generator cli.
