### PR TITLE
Fix bug where rewrites or includes are not provided

### DIFF
--- a/Source/JavaScript/generateAction.ts
+++ b/Source/JavaScript/generateAction.ts
@@ -19,8 +19,8 @@ export const generateAction = (target: GenerationTarget, action: GenerateActionC
             target,
             output: options.O,
             paths,
-            includes: options.I,
-            rewrites: options.R.map(_ => {
+            includes: options.I ?? [],
+            rewrites: (options.R ?? []).map(_ => {
                 const [from, to] = _.split(':',2);
                 const [pkg, pkgName] = to.split('=', 2);
                 if (pkg === 'pkg') {


### PR DESCRIPTION
## Summary

Fix bug where no rewrites or includes were provided to JS/TS generator cli.

### Fixed

- Defaulting to empty arrays for rewrites and includes for the JS/TS generator cli.