### PR TITLE
Use the @grpc/grpc-js for generated TS files

### DIFF
--- a/Source/JavaScript/Generator.ts
+++ b/Source/JavaScript/Generator.ts
@@ -49,7 +49,7 @@ export class Generator {
                 ...options.includes.map(_ => `-I${_}`),
                 protoFile);
             await protocTS(
-                `--ts_out=${buildDir}`,
+                `--ts_out=grpc_js:${buildDir}`,
                 ...options.includes.map(_ => `-I${_}`),
                 protoFile);
         }


### PR DESCRIPTION
## Summary

Changed config of the TS compiler so that it `uses @grpc/grpc-js` imports.

### Fixed

- Changed config of the TS compiler so that it `uses @grpc/grpc-js` imports.
