### PR TITLE
Add ability to keep some source files when re-generating protobuf files.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,7 @@
 name: CI/CD Workflow
 
 env:
-  PRERELEASE_BRANCHES: upgradetools # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: keepfiles # Comma separated list of prerelease branch names. 'alpha,rc, ...'
   NUGET_OUTPUT: Artifacts/NuGet
 
 on:

--- a/Source/MSBuild/Dolittle.Protobuf.MSBuild.props
+++ b/Source/MSBuild/Dolittle.Protobuf.MSBuild.props
@@ -2,5 +2,6 @@
     <PropertyGroup>
         <DolittleProtoProject>NotSet</DolittleProtoProject>
         <DolittleProtoRoot>../</DolittleProtoRoot>
+        <DolittleProtoKeepFiles></DolittleProtoKeepFiles>
     </PropertyGroup>
 </Project>

--- a/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
+++ b/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
@@ -18,7 +18,7 @@
 
     <Target Name="DeleteSourceFiles" BeforeTargets="BeforeBuild">
         <ItemGroup>
-            <FilesToDelete Include="**/*.cs"/>
+            <FilesToDelete Include="**/*.cs" Exclude="$(DolittleProtoKeepFiles)"/>
         </ItemGroup>
         <Delete Files="@(FilesToDelete)"/>
     </Target>


### PR DESCRIPTION
## Summary

Add ability to keep some source files for .NET protobuf build projects.

### Added

- The `<DolittleProtoKeepFiles>` MSbuild property that excludes the listed files from the `DeleteSourceFiles` target.
