### PR TITLE
Bring back compilation of generated .NET protobuf files

### DIFF
--- a/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
+++ b/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
@@ -3,6 +3,7 @@
         <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
         <IncludeSource>True</IncludeSource>
         <Protobuf_NoWarnMissingExpected>true</Protobuf_NoWarnMissingExpected>
+        <Protobuf_TouchMissingExpected>true</Protobuf_TouchMissingExpected>
     </PropertyGroup>
 
     <Import Project="$(NuGetPackageRoot)grpc.tools/2.41.0/build/Grpc.Tools.props"/>
@@ -11,9 +12,8 @@
     <ItemGroup>
         <Protobuf Include="$(DolittleProtoProject)/**/*.proto"
                     ProtoRoot="$(DolittleProtoRoot)"
-                    OutputDir="%(RecursiveDir)" 
-                    GrpcServices="Both" 
-                    CompileOutputs="False" />
+                    OutputDir="%(RecursiveDir)"
+                    GrpcServices="Both" />
     </ItemGroup>
 
     <Target Name="DeleteSourceFiles" BeforeTargets="BeforeBuild">


### PR DESCRIPTION
## Summary

Turns back on compilation of generated .NET protobuf code - to make build pipelines with other sources that rely on the generated code works. To be hones I have no idea how these files were actually built in the end - but it must have worked somehow.

### Fixed

- Turn compilation of generated .NET protobuf source back on, and make errors go away by generating empty service files.
