### PR TITLE
Remove grpc package from csproj

### DIFF
--- a/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
+++ b/Source/MSBuild/Dolittle.Protobuf.MSBuild.targets
@@ -6,8 +6,8 @@
         <Protobuf_TouchMissingExpected>true</Protobuf_TouchMissingExpected>
     </PropertyGroup>
 
-    <Import Project="$(NuGetPackageRoot)grpc.tools/2.41.0/build/Grpc.Tools.props"/>
-    <Import Project="$(NuGetPackageRoot)grpc.tools/2.41.0/build/Grpc.Tools.targets"/>
+    <Import Project="$(NuGetPackageRoot)grpc.tools/2.43.0/build/Grpc.Tools.props"/>
+    <Import Project="$(NuGetPackageRoot)grpc.tools/2.43.0/build/Grpc.Tools.targets"/>
 
     <ItemGroup>
         <Protobuf Include="$(DolittleProtoProject)/**/*.proto"

--- a/Source/MSBuild/Protobuf.MSBuild.csproj
+++ b/Source/MSBuild/Protobuf.MSBuild.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.18.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.18.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.41.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.19.4" />
+    <PackageReference Include="Grpc.Tools" Version="2.43.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/MSBuild/Protobuf.MSBuild.csproj
+++ b/Source/MSBuild/Protobuf.MSBuild.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.18.1" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.18.1" />
-    <PackageReference Include="Grpc" Version="2.41.0" />
     <PackageReference Include="Grpc.Tools" Version="2.41.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Update gRPC and Protobuf package dependencies to latest versions and remove unneeded packages.

### Removes
- The gRPC package dependency, it should not be necessary to build gRPC projects.

### Changes
- Update gRPC and Protobuf package versions.
